### PR TITLE
Fixed layouts to not overwrite $.plot.canvasLegend

### DIFF
--- a/src/main/resources/jquery.flot.canvasLegend.layouts.js
+++ b/src/main/resources/jquery.flot.canvasLegend.layouts.js
@@ -1,6 +1,6 @@
 (function(){
     "use strict";
-    $.plot.canvasLegend = $.plot.custom_canvas_legend || {};
+    $.plot.canvasLegend = $.plot.canvasLegend || {};
     /**
      * 
      * @param {Number} seriesIndex


### PR DESCRIPTION
Previously, $.plot.canvasLegend was set to a blank object if $.plot.custom_canvas_legend was not set. This commit fixes that.
